### PR TITLE
remove openjdk upper bound limit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
     sha256: c035591b9238d6832c19ad6e56506631f6330ad5c53868a80fdd5eaea365a467
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
-    - openjdk <18.0.0a0
+    - openjdk
   run:
-    - openjdk <18.0.0a0
+    - openjdk
 
 test:
   commands:


### PR DESCRIPTION
Hello, I think you should remove this upper limit on the OpenJDK. From the Maven documentation, the limit is only on JDK 8,  " Maven 3.9+ requires JDK 8 or above to execute" source: https://maven.apache.org/download.cgi

why set this upper bound limit?